### PR TITLE
Fix 'Add key and translation' command

### DIFF
--- a/src/commands/add-key-and-translation.ts
+++ b/src/commands/add-key-and-translation.ts
@@ -1,4 +1,6 @@
+import { Commands } from "../constants/commands";
 import { CoreUtils } from "../utilities/core-utils";
+import { log } from "../utilities/log";
 import { addKeyToInterface } from "./add-key-to-interface";
 import { addTranslationToCultureFiles } from "./add-translation-to-culture-files";
 
@@ -10,12 +12,15 @@ const addKeyAndTranslation = async (key?: string, translation?: string) => {
     try {
         key = await addKeyToInterface(key);
         if (key == null) {
+            log.debug(
+                `Key from ${Commands.addKeyToInterface} returned: ${key}`
+            );
             return;
         }
 
         return await addTranslationToCultureFiles(key, translation);
     } catch (error) {
-        return await CoreUtils.catch(addKeyAndTranslation, error);
+        CoreUtils.catch("addKeyAndTranslation", error);
     }
 };
 

--- a/src/commands/add-key-to-interface.ts
+++ b/src/commands/add-key-to-interface.ts
@@ -8,6 +8,8 @@ import { StringUtils } from "../utilities/string-utils";
 import { Property } from "../types/property";
 import { InsertionPosition } from "../enums/insertion-position";
 import { CoreUtils } from "../utilities/core-utils";
+import { log } from "../utilities/log";
+import { Commands } from "../constants/commands";
 
 // -----------------------------------------------------------------------------------------
 // #region Public Functions
@@ -25,13 +27,16 @@ const addKeyToInterface = async (key?: string) => {
         }
 
         if (key == null) {
+            log.debug(
+                `Key was not entered from prompt in ${Commands.addKeyToInterface}`
+            );
             return;
         }
 
         const properties = cultureInterface.getProperties();
         const existingProperty = NodeUtils.findPropertyByName(key, properties);
         if (existingProperty != null) {
-            await WindowUtils.error(
+            WindowUtils.error(
                 `Error - key '${key}' already exists in ${_fileAndLineNumber(
                     cultureInterface,
                     existingProperty
@@ -61,7 +66,7 @@ const addKeyToInterface = async (key?: string) => {
             cultureInterface.getProperties()
         )!;
 
-        await WindowUtils.info(
+        WindowUtils.info(
             `Key '${key}' successfully added to ${_fileAndLineNumber(
                 cultureInterface,
                 newProperty
@@ -70,7 +75,7 @@ const addKeyToInterface = async (key?: string) => {
 
         return key;
     } catch (error) {
-        return await CoreUtils.catch(addKeyToInterface, error);
+        CoreUtils.catch("addKeyToInterface", error);
     }
 };
 

--- a/src/commands/add-translation-to-culture-files.ts
+++ b/src/commands/add-translation-to-culture-files.ts
@@ -53,6 +53,10 @@ const addTranslationToCultureFiles = async (
         );
 
         await Promise.all(transformations);
+
+        WindowUtils.info(
+            `Successfully updated ${transformations.length} culture files!`
+        );
     } catch (error) {
         CoreUtils.catch("addTranslationToCultureFiles", error);
     }

--- a/src/commands/add-translation-to-culture-files.ts
+++ b/src/commands/add-translation-to-culture-files.ts
@@ -54,7 +54,7 @@ const addTranslationToCultureFiles = async (
 
         await Promise.all(transformations);
     } catch (error) {
-        return await CoreUtils.catch(addTranslationToCultureFiles, error);
+        CoreUtils.catch("addTranslationToCultureFiles", error);
     }
 };
 
@@ -72,7 +72,7 @@ const _addTranslationToFile = async (
     const baseLanguage = SourceFileUtils.getBaseLanguage(file);
     const resourceObject = SourceFileUtils.getResourcesObject(file);
     if (resourceObject == null) {
-        await WindowUtils.errorResourcesNotFound(file);
+        WindowUtils.errorResourcesNotFound(file);
         return;
     }
 
@@ -132,7 +132,7 @@ const _buildNewProperty = async (
             initializer: StringUtils.quoteEscape(translationResult.text),
         };
     } catch (error) {
-        await WindowUtils.error(
+        WindowUtils.error(
             `Error encountered attempting to translate to '${matchedLanguage}', using English copy instead - ${error}`
         );
     }

--- a/src/commands/replace-translations-from-file.ts
+++ b/src/commands/replace-translations-from-file.ts
@@ -47,7 +47,8 @@ const replaceTranslationsFromFile = async (
             cultureFile
         );
         if (updateResult == null) {
-            return await WindowUtils.error(ERROR_UPDATING_CULTURE_FILE);
+            WindowUtils.error(ERROR_UPDATING_CULTURE_FILE);
+            return;
         }
 
         log.info(_formatUpdateResult(updateResult));
@@ -60,9 +61,9 @@ const replaceTranslationsFromFile = async (
             );
         }
 
-        return await WindowUtils.info(CULTURE_FILE_UPDATED);
+        WindowUtils.info(CULTURE_FILE_UPDATED);
     } catch (error) {
-        return await CoreUtils.catch(replaceTranslationsFromFile, error);
+        CoreUtils.catch("replaceTranslationsFromFile", error);
     }
 };
 
@@ -111,7 +112,7 @@ const _getTranslationsFromFile = async (
 ): Promise<Record<string, string> | undefined> => {
     const inputFiles = await FileUtils.findAll(["**/*.xlsx", "**/*.json"]);
     if (inputFiles.length < 1) {
-        await WindowUtils.error(ERROR_NO_SUPPORTED_FILES_FOUND);
+        WindowUtils.error(ERROR_NO_SUPPORTED_FILES_FOUND);
         return;
     }
 
@@ -140,7 +141,7 @@ const _parseFile = async (
 
         return _sanitizedParsedValues(parsedValues);
     } catch (error) {
-        await WindowUtils.error(error);
+        WindowUtils.error(error);
     }
 };
 
@@ -150,7 +151,7 @@ const _replaceTranslations = async (
 ): Promise<UpdatePropertiesResult | undefined> => {
     const resourceObject = SourceFileUtils.getResourcesObject(file);
     if (resourceObject == null) {
-        await WindowUtils.errorResourcesNotFound(file);
+        WindowUtils.errorResourcesNotFound(file);
         return;
     }
 

--- a/src/utilities/core-utils.ts
+++ b/src/utilities/core-utils.ts
@@ -1,6 +1,7 @@
 import { Commands } from "../constants/commands";
-import { log } from "./log";
+import { log, logPath } from "./log";
 import { WindowUtils } from "./window-utils";
+import * as vscode from "vscode";
 
 // -----------------------------------------------------------------------------------------
 // #region Public Functions
@@ -9,8 +10,10 @@ import { WindowUtils } from "./window-utils";
 const CoreUtils = {
     catch(functionName: keyof typeof Commands, error: any): undefined {
         log.error(`[${functionName}]:`, error);
+
         WindowUtils.error(
-            "An error occurred running command, see log file for more detail."
+            "An error occurred running command, see log file for more detail.",
+            { value: "View log", onSelection: openLogFile }
         );
 
         return undefined;
@@ -18,6 +21,18 @@ const CoreUtils = {
 };
 
 // #endregion Public Functions
+
+// -----------------------------------------------------------------------------------------
+// #region Private Functions
+// -----------------------------------------------------------------------------------------
+
+const openLogFile = async () =>
+    await vscode.commands.executeCommand(
+        "vscode.open",
+        vscode.Uri.file(logPath)
+    );
+
+// #endregion Private Functions
 
 // -----------------------------------------------------------------------------------------
 // #region Exports

--- a/src/utilities/core-utils.ts
+++ b/src/utilities/core-utils.ts
@@ -1,3 +1,4 @@
+import { Commands } from "../constants/commands";
 import { log } from "./log";
 import { WindowUtils } from "./window-utils";
 
@@ -6,9 +7,9 @@ import { WindowUtils } from "./window-utils";
 // -----------------------------------------------------------------------------------------
 
 const CoreUtils = {
-    async catch(fn: Function, error: any): Promise<undefined> {
-        log.error(`[${fn.name}]:`, error);
-        await WindowUtils.error(
+    catch(functionName: keyof typeof Commands, error: any): undefined {
+        log.error(`[${functionName}]:`, error);
+        WindowUtils.error(
             "An error occurred running command, see log file for more detail."
         );
 

--- a/src/utilities/log.ts
+++ b/src/utilities/log.ts
@@ -11,12 +11,14 @@ import { WorkspaceUtils } from "./workspace-utils";
 // #region Constants
 // -----------------------------------------------------------------------------------------
 
+const logPath: string = `${WorkspaceUtils.getFolder()}/kazoo_log.txt`;
+
 const consoleAppender: ConsoleAppender = {
     type: "console",
 };
 
 const fileAppender: FileAppender = {
-    filename: `${WorkspaceUtils.getFolder()}/kazoo_log.txt`,
+    filename: logPath,
     type: "file",
 };
 
@@ -50,6 +52,6 @@ const log = anylogger("kazoo");
 // #region Exports
 // -----------------------------------------------------------------------------------------
 
-export { log };
+export { log, logPath };
 
 // #endregion Exports

--- a/src/utilities/window-utils.ts
+++ b/src/utilities/window-utils.ts
@@ -15,30 +15,30 @@ const { RESOURCES } = SharedConstants;
 // -----------------------------------------------------------------------------------------
 
 const WindowUtils = {
-    error(value: string) {
-        return vscode.window.showErrorMessage(value);
+    error(value: string): void {
+        vscode.window.showErrorMessage(value);
     },
-    errorResourcesNotFound(file: SourceFile) {
+    errorResourcesNotFound(file: SourceFile): void {
         const fileName = file.getBaseName();
         const message = `Expected to find object literal with key '${RESOURCES}' in ${fileName}.`;
-        return this.error(message);
+        this.error(message);
     },
-    info(value: string) {
-        return vscode.window.showInformationMessage(value);
+    info(value: string): void {
+        vscode.window.showInformationMessage(value);
     },
-    prompt(prompt: string) {
+    prompt(prompt: string): Thenable<string | undefined> {
         return vscode.window.showInputBox({
             prompt,
             ignoreFocusOut: true,
         });
     },
-    selection(options: string[]) {
+    selection(options: string[]): Thenable<string | undefined> {
         return vscode.window.showQuickPick(options, {
             ignoreFocusOut: true,
         });
     },
-    warning(value: string) {
-        return vscode.window.showWarningMessage(value);
+    warning(value: string): void {
+        vscode.window.showWarningMessage(value);
     },
 };
 

--- a/src/utilities/window-utils.ts
+++ b/src/utilities/window-utils.ts
@@ -3,6 +3,17 @@ import * as vscode from "vscode";
 import { SharedConstants } from "../constants/shared-constants";
 
 // -----------------------------------------------------------------------------------------
+// #region Interfaces
+// -----------------------------------------------------------------------------------------
+
+interface MessageOption {
+    value: string;
+    onSelection: (value: string) => void;
+}
+
+// #endregion Interfaces
+
+// -----------------------------------------------------------------------------------------
 // #region Constants
 // -----------------------------------------------------------------------------------------
 
@@ -15,16 +26,16 @@ const { RESOURCES } = SharedConstants;
 // -----------------------------------------------------------------------------------------
 
 const WindowUtils = {
-    error(value: string): void {
-        vscode.window.showErrorMessage(value);
+    error(value: string, ...options: MessageOption[]): void {
+        showMessage(vscode.window.showErrorMessage)(value, ...options);
     },
     errorResourcesNotFound(file: SourceFile): void {
         const fileName = file.getBaseName();
         const message = `Expected to find object literal with key '${RESOURCES}' in ${fileName}.`;
         this.error(message);
     },
-    info(value: string): void {
-        vscode.window.showInformationMessage(value);
+    info(value: string, ...options: MessageOption[]): void {
+        showMessage(vscode.window.showInformationMessage)(value, ...options);
     },
     prompt(prompt: string): Thenable<string | undefined> {
         return vscode.window.showInputBox({
@@ -37,17 +48,49 @@ const WindowUtils = {
             ignoreFocusOut: true,
         });
     },
-    warning(value: string): void {
-        vscode.window.showWarningMessage(value);
+    warning(value: string, ...options: MessageOption[]): void {
+        showMessage(vscode.window.showWarningMessage)(value, ...options);
     },
 };
 
 // #endregion Public Functions
 
 // -----------------------------------------------------------------------------------------
+// #region Private Functions
+// -----------------------------------------------------------------------------------------
+
+const showMessage = (
+    messageFn: (
+        value: string,
+        ...optionsValues: string[]
+    ) => Thenable<string | undefined>
+) => (value: string, ...options: MessageOption[]): void => {
+    const values = options.map((option: MessageOption) => option.value);
+    const promise = messageFn(value, ...values);
+
+    const handleSelection = (selected: string | undefined) => {
+        if (selected == null) {
+            return;
+        }
+
+        const handler = options.find(
+            (option: MessageOption) => option.value === selected
+        )?.onSelection;
+
+        handler?.(selected);
+    };
+
+    if (values.length > 0) {
+        promise.then(handleSelection);
+    }
+};
+
+// #endregion Private Functions
+
+// -----------------------------------------------------------------------------------------
 // #region Exports
 // -----------------------------------------------------------------------------------------
 
-export { WindowUtils };
+export { MessageOption, WindowUtils };
 
 // #endregion Exports


### PR DESCRIPTION
Resolves #11 Bug: Add key to interface and translation to culture files stops after key 

- Remove all 'await' calls from VS Code window messages, which are throwing cancellation errors.
- Update catch function to be synchronous and accept key for function name vs. function name reference which is shortened during minification