### PR TITLE
Support: Strict alphabetical slowness

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,9 +1,9 @@
-name: kazoo
+name: build
 
 on:
     push:
         branches: ["*"]
-    pull_request_target:
+    pull_request:
         branches: [main]
     workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 <p align="center">
     <img src="https://raw.githubusercontent.com/brandongregoryscott/kazoo/main/assets/banner.png" width="50%" height="50%"/>
     <br/>
+    <a href="https://github.com/brandongregoryscott/kazoo/actions/workflows/build.yaml">
+        <img alt="build status" src="https://github.com/brandongregoryscott/kazoo/actions/workflows/build.yaml/badge.svg"/>
+    </a>
     <a href="https://github.com/prettier/prettier">
         <img alt="code style: prettier" src="https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square"/>
     </a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "lodash": "4.17.21",
                 "log4js": "6.3.0",
                 "read-excel-file": "5.1.0",
-                "ts-morph": "10.0.1"
+                "ts-morph": "11.0.0"
             },
             "devDependencies": {
                 "@types/faker": "5.5.3",
@@ -79,18 +79,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/@dsherret/to-absolute-glob": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-            "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
-            "dependencies": {
-                "is-absolute": "^1.0.0",
-                "is-negated-glob": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/@eslint/eslintrc": {
@@ -184,15 +172,14 @@
             }
         },
         "node_modules/@ts-morph/common": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.8.1.tgz",
-            "integrity": "sha512-3TC91LfCKCNCW7zYpegoMnMa9VigXtZHQererUM9pCvZKN3ust3ioLA0kfX+UHSzIGln+UYYiRzfOsv0QoiUng==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.10.0.tgz",
+            "integrity": "sha512-6wC+CovwzxLP+bQZcqHJEbZ7ViaIfsid8VzsVjJRkdfCQ8C8K5mm1+9/wkgmn814BPATtgSgFuDmVJnIb8/leg==",
             "dependencies": {
-                "@dsherret/to-absolute-glob": "^2.0.2",
                 "fast-glob": "^3.2.5",
-                "is-negated-glob": "^1.0.0",
+                "minimatch": "^3.0.4",
                 "mkdirp": "^1.0.4",
-                "multimatch": "^5.0.0"
+                "path-browserify": "^1.0.1"
             }
         },
         "node_modules/@ts-morph/common/node_modules/mkdirp": {
@@ -237,7 +224,8 @@
         "node_modules/@types/minimatch": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+            "dev": true
         },
         "node_modules/@types/mocha": {
             "version": "8.0.4",
@@ -596,26 +584,11 @@
                 "sprintf-js": "~1.0.2"
             }
         },
-        "node_modules/array-differ": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
-            "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/array-union": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
             "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/arrify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -1693,18 +1666,6 @@
                 "node": ">= 0.10"
             }
         },
-        "node_modules/is-absolute": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-            "dependencies": {
-                "is-relative": "^1.0.0",
-                "is-windows": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1757,14 +1718,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-negated-glob": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -1782,40 +1735,10 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-relative": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-            "dependencies": {
-                "is-unc-path": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-        },
-        "node_modules/is-unc-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-            "dependencies": {
-                "unc-path-regex": "^0.1.2"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-windows": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/isarray": {
             "version": "1.0.0",
@@ -2160,21 +2083,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
-        "node_modules/multimatch": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
-            "integrity": "sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==",
-            "dependencies": {
-                "@types/minimatch": "^3.0.3",
-                "array-differ": "^3.0.0",
-                "array-union": "^2.1.0",
-                "arrify": "^2.0.1",
-                "minimatch": "^3.0.4"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/nanoid": {
             "version": "3.1.12",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
@@ -2292,6 +2200,11 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/path-browserify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
@@ -2856,12 +2769,11 @@
             "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
         },
         "node_modules/ts-morph": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-10.0.1.tgz",
-            "integrity": "sha512-T1zufImtp5goTLTFhzi7XuKR1y/f+Jwz1gSULzB045LFjXuoqVlR87sfkpyWow8u2JwgusCJrhOnwmHCFNutTQ==",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-11.0.0.tgz",
+            "integrity": "sha512-u5y0jaft5c0sRFnU0K8cZhhsvPUtXjZK5L31JLIhP17qcqo9MDjwsSYLg3UryQDzlktv8wyf/UtoqpFLDYHijg==",
             "dependencies": {
-                "@dsherret/to-absolute-glob": "^2.0.2",
-                "@ts-morph/common": "~0.8.0",
+                "@ts-morph/common": "~0.10.0",
                 "code-block-writer": "^10.1.1"
             }
         },
@@ -2923,14 +2835,6 @@
             },
             "engines": {
                 "node": ">=4.2.0"
-            }
-        },
-        "node_modules/unc-path-regex": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/unique-string": {
@@ -3418,15 +3322,6 @@
                 }
             }
         },
-        "@dsherret/to-absolute-glob": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-            "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
-            "requires": {
-                "is-absolute": "^1.0.0",
-                "is-negated-glob": "^1.0.0"
-            }
-        },
         "@eslint/eslintrc": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
@@ -3496,15 +3391,14 @@
             "dev": true
         },
         "@ts-morph/common": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.8.1.tgz",
-            "integrity": "sha512-3TC91LfCKCNCW7zYpegoMnMa9VigXtZHQererUM9pCvZKN3ust3ioLA0kfX+UHSzIGln+UYYiRzfOsv0QoiUng==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.10.0.tgz",
+            "integrity": "sha512-6wC+CovwzxLP+bQZcqHJEbZ7ViaIfsid8VzsVjJRkdfCQ8C8K5mm1+9/wkgmn814BPATtgSgFuDmVJnIb8/leg==",
             "requires": {
-                "@dsherret/to-absolute-glob": "^2.0.2",
                 "fast-glob": "^3.2.5",
-                "is-negated-glob": "^1.0.0",
+                "minimatch": "^3.0.4",
                 "mkdirp": "^1.0.4",
-                "multimatch": "^5.0.0"
+                "path-browserify": "^1.0.1"
             },
             "dependencies": {
                 "mkdirp": {
@@ -3545,7 +3439,8 @@
         "@types/minimatch": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+            "dev": true
         },
         "@types/mocha": {
             "version": "8.0.4",
@@ -3840,20 +3735,11 @@
                 "sprintf-js": "~1.0.2"
             }
         },
-        "array-differ": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
-            "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg=="
-        },
         "array-union": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
-        },
-        "arrify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true
         },
         "astral-regex": {
             "version": "2.0.0",
@@ -4715,15 +4601,6 @@
             "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
             "dev": true
         },
-        "is-absolute": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-            "requires": {
-                "is-relative": "^1.0.0",
-                "is-windows": "^1.0.1"
-            }
-        },
         "is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -4761,11 +4638,6 @@
                 "is-extglob": "^2.1.1"
             }
         },
-        "is-negated-glob": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI="
-        },
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4777,31 +4649,10 @@
             "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
             "dev": true
         },
-        "is-relative": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-            "requires": {
-                "is-unc-path": "^1.0.0"
-            }
-        },
         "is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-        },
-        "is-unc-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-            "requires": {
-                "unc-path-regex": "^0.1.2"
-            }
-        },
-        "is-windows": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
         },
         "isarray": {
             "version": "1.0.0",
@@ -5088,18 +4939,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
-        "multimatch": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
-            "integrity": "sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==",
-            "requires": {
-                "@types/minimatch": "^3.0.3",
-                "array-differ": "^3.0.0",
-                "array-union": "^2.1.0",
-                "arrify": "^2.0.1",
-                "minimatch": "^3.0.4"
-            }
-        },
         "nanoid": {
             "version": "3.1.12",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
@@ -5187,6 +5026,11 @@
             "requires": {
                 "callsites": "^3.0.0"
             }
+        },
+        "path-browserify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
         },
         "path-exists": {
             "version": "4.0.0",
@@ -5643,12 +5487,11 @@
             "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
         },
         "ts-morph": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-10.0.1.tgz",
-            "integrity": "sha512-T1zufImtp5goTLTFhzi7XuKR1y/f+Jwz1gSULzB045LFjXuoqVlR87sfkpyWow8u2JwgusCJrhOnwmHCFNutTQ==",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-11.0.0.tgz",
+            "integrity": "sha512-u5y0jaft5c0sRFnU0K8cZhhsvPUtXjZK5L31JLIhP17qcqo9MDjwsSYLg3UryQDzlktv8wyf/UtoqpFLDYHijg==",
             "requires": {
-                "@dsherret/to-absolute-glob": "^2.0.2",
-                "@ts-morph/common": "~0.8.0",
+                "@ts-morph/common": "~0.10.0",
                 "code-block-writer": "^10.1.1"
             }
         },
@@ -5695,11 +5538,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
             "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
             "dev": true
-        },
-        "unc-path-regex": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
         },
         "unique-string": {
             "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
                 "@types/lodash": "4.14.168",
                 "@types/mocha": "8.0.4",
                 "@types/shelljs": "0.8.8",
+                "@types/sinon": "^10.0.2",
                 "@types/vscode": "1.54.0",
                 "@typescript-eslint/eslint-plugin": "4.14.1",
                 "@typescript-eslint/parser": "4.14.1",
@@ -33,6 +34,7 @@
                 "prettier": "2.2.1",
                 "rimraf": "3.0.2",
                 "shelljs": "0.8.4",
+                "sinon": "^11.1.1",
                 "typescript": "4.1.3",
                 "upath": "2.0.1",
                 "vscode-test": "1.5.0"
@@ -151,6 +153,41 @@
                 "node": ">=6"
             }
         },
+        "node_modules/@sinonjs/commons": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+            "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+            "dev": true,
+            "dependencies": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "node_modules/@sinonjs/fake-timers": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+            "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/commons": "^1.7.0"
+            }
+        },
+        "node_modules/@sinonjs/samsam": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
+            "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/commons": "^1.6.0",
+                "lodash.get": "^4.4.2",
+                "type-detect": "^4.0.8"
+            }
+        },
+        "node_modules/@sinonjs/text-encoding": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+            "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+            "dev": true
+        },
         "node_modules/@szmarczak/http-timer": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -247,6 +284,15 @@
             "dependencies": {
                 "@types/glob": "*",
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@types/sinon": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.2.tgz",
+            "integrity": "sha512-BHn8Bpkapj8Wdfxvh2jWIUoaYB/9/XhsL0oOvBfRagJtKlSl9NWPcFOz2lRukI9szwGxFtYZCTejJSqsGDbdmw==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/fake-timers": "^7.1.0"
             }
         },
         "node_modules/@types/vscode": {
@@ -1806,6 +1852,12 @@
                 "set-immediate-shim": "~1.0.1"
             }
         },
+        "node_modules/just-extend": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+            "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+            "dev": true
+        },
         "node_modules/keyv": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -1856,6 +1908,12 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "node_modules/lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+            "dev": true
         },
         "node_modules/log-symbols": {
             "version": "4.0.0",
@@ -2101,6 +2159,19 @@
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
+        "node_modules/nise": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
+            "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/commons": "^1.7.0",
+                "@sinonjs/fake-timers": "^7.0.4",
+                "@sinonjs/text-encoding": "^0.7.1",
+                "just-extend": "^4.0.2",
+                "path-to-regexp": "^1.7.0"
+            }
+        },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2236,6 +2307,21 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true
+        },
+        "node_modules/path-to-regexp": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+            "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+            "dev": true,
+            "dependencies": {
+                "isarray": "0.0.1"
+            }
+        },
+        "node_modules/path-to-regexp/node_modules/isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
             "dev": true
         },
         "node_modules/path-type": {
@@ -2565,6 +2651,54 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
             "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
         },
+        "node_modules/sinon": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
+            "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/commons": "^1.8.3",
+                "@sinonjs/fake-timers": "^7.1.0",
+                "@sinonjs/samsam": "^6.0.2",
+                "diff": "^5.0.0",
+                "nise": "^5.1.0",
+                "supports-color": "^7.2.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/sinon"
+            }
+        },
+        "node_modules/sinon/node_modules/diff": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+            "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/sinon/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/sinon/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -2805,6 +2939,15 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/type-fest": {
@@ -3376,6 +3519,41 @@
             "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
             "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
         },
+        "@sinonjs/commons": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+            "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+            "dev": true,
+            "requires": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "@sinonjs/fake-timers": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+            "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.7.0"
+            }
+        },
+        "@sinonjs/samsam": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
+            "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.6.0",
+                "lodash.get": "^4.4.2",
+                "type-detect": "^4.0.8"
+            }
+        },
+        "@sinonjs/text-encoding": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+            "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+            "dev": true
+        },
         "@szmarczak/http-timer": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -3462,6 +3640,15 @@
             "requires": {
                 "@types/glob": "*",
                 "@types/node": "*"
+            }
+        },
+        "@types/sinon": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.2.tgz",
+            "integrity": "sha512-BHn8Bpkapj8Wdfxvh2jWIUoaYB/9/XhsL0oOvBfRagJtKlSl9NWPcFOz2lRukI9szwGxFtYZCTejJSqsGDbdmw==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/fake-timers": "^7.1.0"
             }
         },
         "@types/vscode": {
@@ -4717,6 +4904,12 @@
                 "set-immediate-shim": "~1.0.1"
             }
         },
+        "just-extend": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+            "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+            "dev": true
+        },
         "keyv": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -4761,6 +4954,12 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+            "dev": true
         },
         "log-symbols": {
             "version": "4.0.0",
@@ -4951,6 +5150,19 @@
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
+        "nise": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
+            "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.7.0",
+                "@sinonjs/fake-timers": "^7.0.4",
+                "@sinonjs/text-encoding": "^0.7.1",
+                "just-extend": "^4.0.2",
+                "path-to-regexp": "^1.7.0"
+            }
+        },
         "normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -5054,6 +5266,23 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true
+        },
+        "path-to-regexp": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+            "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+            "dev": true,
+            "requires": {
+                "isarray": "0.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                }
+            }
         },
         "path-type": {
             "version": "4.0.0",
@@ -5314,6 +5543,43 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
             "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
         },
+        "sinon": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
+            "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.8.3",
+                "@sinonjs/fake-timers": "^7.1.0",
+                "@sinonjs/samsam": "^6.0.2",
+                "diff": "^5.0.0",
+                "nise": "^5.1.0",
+                "supports-color": "^7.2.0"
+            },
+            "dependencies": {
+                "diff": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+                    "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
         "slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -5518,6 +5784,12 @@
             "requires": {
                 "prelude-ls": "^1.2.1"
             }
+        },
+        "type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true
         },
         "type-fest": {
             "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
         "@types/lodash": "4.14.168",
         "@types/mocha": "8.0.4",
         "@types/shelljs": "0.8.8",
+        "@types/sinon": "10.0.2",
         "@types/vscode": "1.54.0",
         "@typescript-eslint/eslint-plugin": "4.14.1",
         "@typescript-eslint/parser": "4.14.1",
@@ -97,6 +98,7 @@
         "prettier": "2.2.1",
         "rimraf": "3.0.2",
         "shelljs": "0.8.4",
+        "sinon": "11.1.1",
         "typescript": "4.1.3",
         "upath": "2.0.1",
         "vscode-test": "1.5.0"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
         "lodash": "4.17.21",
         "log4js": "6.3.0",
         "read-excel-file": "5.1.0",
-        "ts-morph": "10.0.1"
+        "ts-morph": "11.0.0"
     },
     "description": "Ease the burden of adding localized keys and strings to multiple typed culture files",
     "devDependencies": {

--- a/src/commands/add-translation-to-culture-files.ts
+++ b/src/commands/add-translation-to-culture-files.ts
@@ -135,14 +135,14 @@ const _buildNewProperty = async (
     }
 
     try {
-        const translationResult = await translate(value, {
+        const translation = await StringUtils.translate(value, {
             from: LanguageCode.Default,
             to: matchedLanguage,
         });
 
         const translatedProperty = {
             ...property,
-            initializer: StringUtils.quoteEscape(translationResult.text),
+            initializer: StringUtils.quoteEscape(translation),
         };
         return translatedProperty;
     } catch (error) {

--- a/src/test/shared/describes.ts
+++ b/src/test/shared/describes.ts
@@ -1,20 +1,21 @@
 import { InsertionPosition } from "../../enums/insertion-position";
-import { Suite, describe } from "mocha";
+import { beforeEach, describe } from "mocha";
+import { TestUtils } from "../test-utils";
 
 // -----------------------------------------------------------------------------------------
 // #region Public Functions
 // -----------------------------------------------------------------------------------------
 
-const whenEndPosition = (fn: (this: Suite) => void) =>
+const whenEndPosition = (fn: () => void) =>
     whenInsertionPosition(InsertionPosition.End)(fn);
 
-const whenLooseAlphabetical = (fn: (this: Suite) => void) =>
+const whenLooseAlphabetical = (fn: () => void) =>
     whenInsertionPosition(InsertionPosition.LooseAlphabetical)(fn);
 
-const whenStartPosition = (fn: (this: Suite) => void) =>
+const whenStartPosition = (fn: () => void) =>
     whenInsertionPosition(InsertionPosition.Start)(fn);
 
-const whenStrictAlphabetical = (fn: (this: Suite) => void) =>
+const whenStrictAlphabetical = (fn: () => void) =>
     whenInsertionPosition(InsertionPosition.StrictAlphabetical)(fn);
 
 // #endregion Public Functions
@@ -24,8 +25,17 @@ const whenStrictAlphabetical = (fn: (this: Suite) => void) =>
 // -----------------------------------------------------------------------------------------
 
 const whenInsertionPosition = (insertionPosition: InsertionPosition) => (
-    fn: (this: Suite) => void
-) => describe(`when insertionPosition '${insertionPosition}'`, fn);
+    fn: () => void
+) =>
+    describe(`when insertionPosition '${insertionPosition}'`, () => {
+        beforeEach(async () => {
+            await TestUtils.mergeConfig({
+                insertionPosition,
+            });
+        });
+
+        fn();
+    });
 
 // #endregion Private Functions
 

--- a/src/test/shared/hooks.ts
+++ b/src/test/shared/hooks.ts
@@ -1,0 +1,29 @@
+import { TestFixtures, TestUtils } from "../test-utils";
+import { beforeEach } from "mocha";
+
+// -----------------------------------------------------------------------------------------
+// #region Public Functions
+// -----------------------------------------------------------------------------------------
+
+/**
+ * Copies the given test fixture to a temporary directory and sets the configuration to match
+ */
+const useFixture = (fixture: TestFixtures) => {
+    beforeEach(async () => {
+        TestUtils.cleanTmpDirectory();
+
+        const tmpDirectory = TestUtils.copyFixturesToTmpDirectory(fixture);
+
+        await TestUtils.mergeConfigForTmpDirectory(tmpDirectory);
+    });
+};
+
+// #endregion Public Functions
+
+// -----------------------------------------------------------------------------------------
+// #region Exports
+// -----------------------------------------------------------------------------------------
+
+export { useFixture };
+
+// #endregion Exports

--- a/src/test/shared/specs.ts
+++ b/src/test/shared/specs.ts
@@ -14,7 +14,7 @@ const shouldActivate = async () => {
     await extension?.activate();
 
     // Assert
-    assert.equal(extension?.isActive, true);
+    assert.strictEqual(extension?.isActive, true);
 };
 
 // #endregion Public Functions

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -16,6 +16,8 @@ import {
 } from "../shared/describes";
 import { Language } from "../../enums/language";
 import faker from "faker";
+import sinon from "sinon";
+import { StringUtils } from "../../utilities/string-utils";
 
 suite("kazoo", () => {
     // -----------------------------------------------------------------------------------------
@@ -237,6 +239,9 @@ suite("kazoo", () => {
             });
         });
 
+        /**
+         * https://github.com/brandongregoryscott/kazoo/issues/17
+         */
         describe("given culture file has 100+ entries", () => {
             beforeEach(async () => {
                 const tmpDirectory = TestUtils.copyFixturesToTmpDirectory(
@@ -248,14 +253,18 @@ suite("kazoo", () => {
             });
 
             whenStrictAlphabetical(() => {
-                test.only("performs full sort of culture file in under 3s", async () => {
+                test.only("performs full sort of culture file in under 1s", async () => {
                     // Arrange
+                    const expected = 1;
                     await TestUtils.mergeConfig({
                         insertionPosition: InsertionPosition.StrictAlphabetical,
                     });
                     const start = new Date();
-                    const key = faker.datatype.string();
+                    const key = faker.random.word();
                     const translation = faker.random.words();
+                    sinon
+                        .stub(StringUtils, "translate")
+                        .resolves(faker.random.words());
 
                     // Act
                     await kazoo.addTranslationToCultureFiles(key, translation);
@@ -265,9 +274,9 @@ suite("kazoo", () => {
                     const elapsedSeconds: number =
                         ((end as any) - (start as any)) / 1000;
                     assert.equal(
-                        elapsedSeconds < 3,
+                        elapsedSeconds < expected,
                         true,
-                        `Expected ${InsertionPosition.StrictAlphabetical} sorting to complete in 3s or less. Actual: ${elapsedSeconds}`
+                        `Expected ${InsertionPosition.StrictAlphabetical} sorting to complete in ${expected}s or less. Actual: ${elapsedSeconds}`
                     );
                 });
             });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -16,6 +16,7 @@ import {
     whenStrictAlphabetical,
 } from "../shared/describes";
 import { Language } from "../../enums/language";
+import faker from "faker";
 
 suite("kazoo", () => {
     // -----------------------------------------------------------------------------------------
@@ -232,6 +233,45 @@ suite("kazoo", () => {
                         actualIndex,
                         expectedAfterIndex + 1,
                         `Expected '${key}' to appear alphabetically after '${expectedAfterKey}'`
+                    );
+                });
+            });
+        });
+
+        describe("given culture file has 100+ entries", () => {
+            beforeEach(async () => {
+                const tmpDirectory = TestUtils.copyFixturesToTmpDirectory(
+                    TestFixtures.SixHundredKeys
+                );
+                await TestUtils.mergeConfigForTmpDirectory(tmpDirectory);
+
+                await shouldActivate();
+            });
+
+            whenStrictAlphabetical(() => {
+                test.only("performs full sort of culture file in under 3s", async () => {
+                    // Arrange
+                    await TestUtils.mergeConfig({
+                        insertionPosition: InsertionPosition.StrictAlphabetical,
+                    });
+                    const start = new Date();
+                    const key = faker.datatype.string();
+                    const translation = faker.random.words();
+
+                    // Act
+                    const result = await kazoo.addTranslationToCultureFiles(
+                        key,
+                        translation
+                    );
+
+                    // Assert
+                    const end = new Date();
+                    const elapsedSeconds: number =
+                        ((end as any) - (start as any)) / 1000;
+                    assert.equal(
+                        elapsedSeconds < 3,
+                        true,
+                        `Expected ${InsertionPosition.StrictAlphabetical} sorting to complete in 3s or less. Actual: ${elapsedSeconds}`
                     );
                 });
             });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -414,7 +414,7 @@ suite("kazoo", () => {
             whenStrictAlphabetical(() => {
                 const expected = 1.25;
 
-                test(`performs full sort of culture file in under ${expected}s`, async () => {
+                test.skip(`performs full sort of culture file in under ${expected}s`, async () => {
                     // Arrange
                     await TestUtils.mergeConfig({
                         insertionPosition: InsertionPosition.StrictAlphabetical,

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -20,6 +20,7 @@ import sinon from "sinon";
 import { StringUtils } from "../../utilities/string-utils";
 import { PropertyAssignment, PropertySignature } from "ts-morph";
 import { Property } from "../../types/property";
+import { useFixture } from "../shared/hooks";
 
 suite("kazoo", () => {
     // -----------------------------------------------------------------------------------------
@@ -35,6 +36,8 @@ suite("kazoo", () => {
         translateStub = sinon
             .stub(StringUtils, "translate")
             .resolves(faker.random.words());
+
+        await shouldActivate();
     });
 
     afterEach(() => {
@@ -57,19 +60,8 @@ suite("kazoo", () => {
     // -----------------------------------------------------------------------------------------
 
     describe("addKeyToInterface", () => {
-        beforeEach(() => {
-            TestUtils.cleanTmpDirectory();
-        });
-
         describe("given interface is empty", () => {
-            beforeEach(async () => {
-                const tmpDirectory = TestUtils.copyFixturesToTmpDirectory(
-                    TestFixtures.Empty
-                );
-                await TestUtils.mergeConfigForTmpDirectory(tmpDirectory);
-
-                await shouldActivate();
-            });
+            useFixture(TestFixtures.Empty);
 
             test("inserts key into interface, returns created key", async () => {
                 // Arrange
@@ -86,14 +78,7 @@ suite("kazoo", () => {
         });
 
         describe("given interface has alphabetized keys", () => {
-            beforeEach(async () => {
-                const tmpDirectory = TestUtils.copyFixturesToTmpDirectory(
-                    TestFixtures.FiveKeysAlphabetized
-                );
-                await TestUtils.mergeConfigForTmpDirectory(tmpDirectory);
-
-                await shouldActivate();
-            });
+            useFixture(TestFixtures.FiveKeysAlphabetized);
 
             whenLooseAlphabetical(() => {
                 test("inserts key into interface at expected position, returns created key", async () => {
@@ -117,9 +102,6 @@ suite("kazoo", () => {
                 test("inserts key into interface at expected position, returns created key", async () => {
                     // Arrange
                     const key = "testKey";
-                    await TestUtils.mergeConfig({
-                        insertionPosition: InsertionPosition.StrictAlphabetical,
-                    });
 
                     // Act
                     const result = await kazoo.addKeyToInterface(key);
@@ -138,9 +120,6 @@ suite("kazoo", () => {
                 test("inserts key into interface at expected position, returns created key", async () => {
                     // Arrange
                     const key = "testKey";
-                    await TestUtils.mergeConfig({
-                        insertionPosition: InsertionPosition.Start,
-                    });
 
                     // Act
                     const result = await kazoo.addKeyToInterface(key);
@@ -159,9 +138,6 @@ suite("kazoo", () => {
                 test("inserts key into interface at expected position, returns created key", async () => {
                     // Arrange
                     const key = "testKey";
-                    await TestUtils.mergeConfig({
-                        insertionPosition: InsertionPosition.End,
-                    });
 
                     // Act
                     const result = await kazoo.addKeyToInterface(key);
@@ -178,21 +154,11 @@ suite("kazoo", () => {
         });
 
         describe("given interface is not strictly alphabetized", () => {
-            beforeEach(async () => {
-                const tmpDirectory = TestUtils.copyFixturesToTmpDirectory(
-                    TestFixtures.SixHundredKeys
-                );
-                await TestUtils.mergeConfigForTmpDirectory(tmpDirectory);
-
-                await shouldActivate();
-            });
+            useFixture(TestFixtures.SixHundredKeys);
 
             whenStrictAlphabetical(() => {
                 test("performs full sort of interface", async () => {
                     // Arrange
-                    await TestUtils.mergeConfig({
-                        insertionPosition: InsertionPosition.StrictAlphabetical,
-                    });
                     const key = faker.random.word().toLowerCase();
 
                     // Act
@@ -228,23 +194,13 @@ suite("kazoo", () => {
          * https://github.com/brandongregoryscott/kazoo/issues/17
          */
         describe("given interface has 100+ keys", () => {
-            beforeEach(async () => {
-                const tmpDirectory = TestUtils.copyFixturesToTmpDirectory(
-                    TestFixtures.SixHundredKeys
-                );
-                await TestUtils.mergeConfigForTmpDirectory(tmpDirectory);
-
-                await shouldActivate();
-            });
+            useFixture(TestFixtures.SixHundredKeys);
 
             whenStrictAlphabetical(() => {
                 const expected = 1.25;
 
                 test(`performs full sort of interface in under ${expected}s`, async () => {
                     // Arrange
-                    await TestUtils.mergeConfig({
-                        insertionPosition: InsertionPosition.StrictAlphabetical,
-                    });
                     const start = new Date();
                     const key = faker.random.word().toLowerCase();
 
@@ -273,21 +229,11 @@ suite("kazoo", () => {
 
     describe("addTranslationToCultureFiles", () => {
         describe("given culture file is not strictly alphabetized", () => {
-            beforeEach(async () => {
-                const tmpDirectory = TestUtils.copyFixturesToTmpDirectory(
-                    TestFixtures.SixHundredKeys
-                );
-                await TestUtils.mergeConfigForTmpDirectory(tmpDirectory);
-
-                await shouldActivate();
-            });
+            useFixture(TestFixtures.SixHundredKeys);
 
             whenStrictAlphabetical(() => {
                 test("performs full sort of culture file", async () => {
                     // Arrange
-                    await TestUtils.mergeConfig({
-                        insertionPosition: InsertionPosition.StrictAlphabetical,
-                    });
                     const key = faker.random.word().toLowerCase();
                     const translation = faker.random.words();
 
@@ -330,14 +276,7 @@ suite("kazoo", () => {
          * https://github.com/brandongregoryscott/kazoo/issues/15
          */
         describe("given culture file has spread assignment in object literal", () => {
-            beforeEach(async () => {
-                const tmpDirectory = TestUtils.copyFixturesToTmpDirectory(
-                    TestFixtures.Issue15
-                );
-                await TestUtils.mergeConfigForTmpDirectory(tmpDirectory);
-
-                await shouldActivate();
-            });
+            useFixture(TestFixtures.Issue15);
 
             whenLooseAlphabetical(() => {
                 test("inserts translation into culture file at expected position, returns list of translations", async () => {
@@ -402,23 +341,13 @@ suite("kazoo", () => {
          * https://github.com/brandongregoryscott/kazoo/issues/17
          */
         describe("given culture file has 100+ entries", () => {
-            beforeEach(async () => {
-                const tmpDirectory = TestUtils.copyFixturesToTmpDirectory(
-                    TestFixtures.SixHundredKeys
-                );
-                await TestUtils.mergeConfigForTmpDirectory(tmpDirectory);
-
-                await shouldActivate();
-            });
+            useFixture(TestFixtures.SixHundredKeys);
 
             whenStrictAlphabetical(() => {
                 const expected = 1.25;
 
                 test.skip(`performs full sort of culture file in under ${expected}s`, async () => {
                     // Arrange
-                    await TestUtils.mergeConfig({
-                        insertionPosition: InsertionPosition.StrictAlphabetical,
-                    });
                     const start = new Date();
                     const key = faker.random.word();
                     const translation = faker.random.words();

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,5 +1,4 @@
 import assert from "assert";
-import vscode from "vscode";
 import { describe, beforeEach } from "mocha";
 import * as kazoo from "../../extension";
 import { TestFixtures, TestUtils } from "../test-utils";
@@ -259,10 +258,7 @@ suite("kazoo", () => {
                     const translation = faker.random.words();
 
                     // Act
-                    const result = await kazoo.addTranslationToCultureFiles(
-                        key,
-                        translation
-                    );
+                    await kazoo.addTranslationToCultureFiles(key, translation);
 
                     // Assert
                     const end = new Date();

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { describe, beforeEach } from "mocha";
+import { describe, beforeEach, afterEach } from "mocha";
 import * as kazoo from "../../extension";
 import { TestFixtures, TestUtils } from "../test-utils";
 import { ProjectUtils } from "../../utilities/project-utils";
@@ -26,8 +26,17 @@ suite("kazoo", () => {
 
     const { findPropertyIndexByName } = NodeUtils;
 
+    let translateStub: sinon.SinonStub;
     beforeEach(async () => {
         await TestUtils.resetConfig();
+
+        translateStub = sinon
+            .stub(StringUtils, "translate")
+            .resolves(faker.random.words());
+    });
+
+    afterEach(() => {
+        translateStub.restore();
     });
 
     // #endregion Setup
@@ -253,18 +262,16 @@ suite("kazoo", () => {
             });
 
             whenStrictAlphabetical(() => {
-                test.only("performs full sort of culture file in under 1s", async () => {
+                const expected = 1.25;
+
+                test(`performs full sort of culture file in under ${expected}s`, async () => {
                     // Arrange
-                    const expected = 1;
                     await TestUtils.mergeConfig({
                         insertionPosition: InsertionPosition.StrictAlphabetical,
                     });
                     const start = new Date();
                     const key = faker.random.word();
                     const translation = faker.random.words();
-                    sinon
-                        .stub(StringUtils, "translate")
-                        .resolves(faker.random.words());
 
                     // Act
                     await kazoo.addTranslationToCultureFiles(key, translation);
@@ -274,9 +281,9 @@ suite("kazoo", () => {
                     const elapsedSeconds: number =
                         ((end as any) - (start as any)) / 1000;
                     assert.equal(
-                        elapsedSeconds < expected,
+                        elapsedSeconds <= expected,
                         true,
-                        `Expected ${InsertionPosition.StrictAlphabetical} sorting to complete in ${expected}s or less. Actual: ${elapsedSeconds}`
+                        `Expected '${InsertionPosition.StrictAlphabetical}' sorting to complete in ${expected}s or less. Actual: ${elapsedSeconds}`
                     );
                 });
             });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -167,6 +167,46 @@ suite("kazoo", () => {
                 });
             });
         });
+
+        /**
+         * https://github.com/brandongregoryscott/kazoo/issues/17
+         */
+        describe("given interface has 100+ keys", () => {
+            beforeEach(async () => {
+                const tmpDirectory = TestUtils.copyFixturesToTmpDirectory(
+                    TestFixtures.SixHundredKeys
+                );
+                await TestUtils.mergeConfigForTmpDirectory(tmpDirectory);
+
+                await shouldActivate();
+            });
+
+            whenStrictAlphabetical(() => {
+                const expected = 1.25;
+
+                test.only(`performs full sort of interface in under ${expected}s`, async () => {
+                    // Arrange
+                    await TestUtils.mergeConfig({
+                        insertionPosition: InsertionPosition.StrictAlphabetical,
+                    });
+                    const start = new Date();
+                    const key = faker.random.word().toLowerCase();
+
+                    // Act
+                    await kazoo.addKeyToInterface(key);
+
+                    // Assert
+                    const end = new Date();
+                    const elapsedSeconds: number =
+                        ((end as any) - (start as any)) / 1000;
+                    assert.equal(
+                        elapsedSeconds <= expected,
+                        true,
+                        `Expected '${InsertionPosition.StrictAlphabetical}' sorting to complete in ${expected}s or less. Actual: ${elapsedSeconds}`
+                    );
+                });
+            });
+        });
     });
 
     // #endregion addKeyToInterface

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -8,7 +8,7 @@ export function run(): Promise<void> {
         ui: "tdd",
         color: true,
     });
-    mocha.timeout(10000);
+    mocha.timeout(30000);
 
     const testsRoot = path.resolve(__dirname, "..");
 

--- a/src/types/property.ts
+++ b/src/types/property.ts
@@ -10,9 +10,11 @@ import {
 // -----------------------------------------------------------------------------------------
 
 type Property = PropertyAssignment | PropertySignature;
-type PropertyAndStructure =
-    | [PropertyAssignment, PropertyAssignmentStructure]
-    | [PropertySignature, PropertySignatureStructure];
+type PropertyStructure<
+    TProperty extends Property
+> = TProperty extends PropertyAssignment
+    ? PropertyAssignmentStructure
+    : PropertySignatureStructure;
 
 // #endregion Types
 
@@ -20,6 +22,6 @@ type PropertyAndStructure =
 // #region Exports
 // -----------------------------------------------------------------------------------------
 
-export { Property, PropertyAndStructure };
+export { Property, PropertyStructure };
 
 // #endregion Exports

--- a/src/utilities/node-utils.ts
+++ b/src/utilities/node-utils.ts
@@ -16,6 +16,7 @@ import { Property } from "../types/property";
 import * as _ from "lodash";
 import { StringUtils } from "./string-utils";
 import { UpdatePropertiesResult } from "../interfaces/update-properties-result";
+import { property } from "lodash";
 
 // -----------------------------------------------------------------------------------------
 // #region Public Functions
@@ -159,8 +160,18 @@ const sortPropertyAssignments = (
 ): ObjectLiteralExpression => {
     const existing = getPropertyAssignments(literal);
     const sorted = sortPropertiesByName<PropertyAssignmentStructure>(existing);
-    existing.forEach((property) => property.remove());
-    literal.addProperties(sorted);
+
+    const propertyOutOfOrder = (
+        existingProperty: PropertyAssignment,
+        index: number
+    ) => existingProperty.getName() !== sorted[index].name;
+
+    const sortProperty = (
+        existingProperty: PropertyAssignment,
+        index: number
+    ) => existingProperty.set(sorted[index]);
+
+    existing.filter(propertyOutOfOrder).forEach(sortProperty);
 
     return literal;
 };

--- a/src/utilities/string-utils.ts
+++ b/src/utilities/string-utils.ts
@@ -2,6 +2,9 @@ import { LanguageCodeMap } from "../constants/language-code-map";
 import { Language } from "../enums/language";
 import { Property } from "../types/property";
 import { NodeUtils } from "./node-utils";
+import translate, {
+    IOptions as TranslateOptions,
+} from "@vitalets/google-translate-api";
 
 // -----------------------------------------------------------------------------------------
 // #region Public Functions
@@ -41,6 +44,13 @@ const StringUtils = {
     },
     stripQuotes(value: string): string {
         return value.replace(/["']/g, "");
+    },
+    async translate(
+        value: string,
+        options?: TranslateOptions
+    ): Promise<string> {
+        const { text } = await translate(value, options);
+        return text;
     },
 };
 


### PR DESCRIPTION
Partially addresses #17 for slowness while strictly alphabetizing an interface. Still working on finding a similar API to `setOrder` for the `ObjectLiteralExpression` node, or another strategy for rebuilding the `resources` object literal in an alphabetized format. 

Includes some test abstractions with shared describes and hooks.