### PR TITLE
Feature/replace key

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
         "build:dist": "npm run esbuild -- --minify",
         "build:test": "tsc --pretty",
         "clean": "rimraf dist tmp **/tmp/* **/*.txt **/*.log",
-        "esbuild": "node ./node_modules/esbuild/bin/esbuild src/extension.ts --bundle --outfile=dist/extension.js --platform=node --external:vscode",
+        "esbuild": "./node_modules/esbuild/bin/esbuild src/extension.ts --bundle --outfile=dist/extension.js --platform=node --external:vscode",
         "lint": "eslint src --ext ts",
         "postvscode:publish": "git add -A && git commit -m \"$npm_package_version\" && git push origin main",
         "prebuild": "npm run clean",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
         "build:dist": "npm run esbuild -- --minify",
         "build:test": "tsc --pretty",
         "clean": "rimraf dist tmp **/tmp/* **/*.txt **/*.log",
-        "esbuild": "./node_modules/esbuild/bin/esbuild src/extension.ts --bundle --outfile=dist/extension.js --platform=node --external:vscode",
+        "esbuild": "node ./node_modules/esbuild/bin/esbuild src/extension.ts --bundle --outfile=dist/extension.js --platform=node --external:vscode",
         "lint": "eslint src --ext ts",
         "postvscode:publish": "git add -A && git commit -m \"$npm_package_version\" && git push origin main",
         "prebuild": "npm run clean",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
         "onCommand:kazoo.addTranslationToCultureFiles",
         "onCommand:kazoo.removeKeyFromInterface",
         "onCommand:kazoo.removeTranslationFromCultureFiles",
+        "onCommand:kazoo.replaceTranslationByKey",
         "onCommand:kazoo.replaceTranslationsFromFile"
     ],
     "author": {
@@ -40,6 +41,11 @@
                 "category": "kazoo",
                 "command": "kazoo.removeTranslationFromCultureFiles",
                 "title": "Remove translation from culture files"
+            },
+            {
+                "category": "kazoo",
+                "command": "kazoo.replaceTranslationByKey",
+                "title": "Replace translation for a specific key"
             },
             {
                 "category": "kazoo",

--- a/src/commands/replace-translation-by-key.ts
+++ b/src/commands/replace-translation-by-key.ts
@@ -1,0 +1,117 @@
+import { WindowUtils } from "../utilities/window-utils";
+import { ProjectUtils } from "../utilities/project-utils";
+import { NodeUtils } from "../utilities/node-utils";
+import { CoreUtils } from "../utilities/core-utils";
+import { log } from "../utilities/log";
+import { Commands } from "../constants/commands";
+import { PropertyUtils } from "../utilities/property-utils";
+import { PropertyAssignment } from "ts-morph";
+import { SourceFileUtils } from "../utilities/source-file-utils";
+import { StringUtils } from "../utilities/string-utils";
+
+// -----------------------------------------------------------------------------------------
+// #region Public Functions
+// -----------------------------------------------------------------------------------------
+
+const replaceTranslationByKey = async (
+    key?: string,
+    cultureFilePath?: string
+) => {
+    try {
+        const cultureInterfaceFile = await ProjectUtils.getCultureInterfaceFile();
+        const cultureInterface = await ProjectUtils.getCultureInterface();
+        const interfaceName = cultureInterface.getName();
+        const interfaceProperties = cultureInterface.getProperties();
+        const propertyNames = PropertyUtils.getNames(interfaceProperties);
+        if (key == null) {
+            key = await WindowUtils.selection(propertyNames);
+        }
+
+        if (key == null) {
+            log.debug(
+                `Key was not entered from prompt in ${Commands.replaceTranslationByKey}`
+            );
+            return;
+        }
+
+        const existingProperty = NodeUtils.findPropertyByName(
+            key,
+            interfaceProperties
+        );
+        if (existingProperty == null) {
+            WindowUtils.info(
+                `Key '${key}' does not exist in ${interfaceName}.`
+            );
+            return;
+        }
+
+        const cultureFiles = await ProjectUtils.getCultureFiles();
+        const cultureFilePaths = cultureFiles.map((file) => file.getFilePath());
+
+        if (cultureFilePath == null) {
+            cultureFilePath = await WindowUtils.selection(cultureFilePaths);
+        }
+
+        if (cultureFilePath == null) {
+            log.debug("No cultureFilePath entered - not continuing.");
+            return;
+        }
+
+        const cultureFile = cultureFiles.find(
+            (file) => file.getFilePath() === cultureFilePath
+        );
+
+        if (cultureFile == null) {
+            log.warn(
+                "cultureFile was unexpectedly null",
+                cultureFilePath,
+                cultureFile
+            );
+            return;
+        }
+
+        const resources = SourceFileUtils.getResourcesObject(cultureFile);
+        const propertyAssignments = NodeUtils.getPropertyAssignments(
+            resources!
+        );
+        const property = NodeUtils.findPropertyByName<PropertyAssignment>(
+            key,
+            propertyAssignments
+        );
+        if (property == null) {
+            log.warn("Could not find translation for key", key, resources);
+            return;
+        }
+
+        const originalCopy = property.getInitializer()?.getText();
+        if (originalCopy == null) {
+            log.warn("Original copy was unexpectedly null", property);
+            return;
+        }
+
+        const updatedCopy = await WindowUtils.prefilledPrompt(
+            `Enter updated copy for '${key}'`,
+            StringUtils.stripQuotes(originalCopy)
+        );
+
+        if (updatedCopy == null) {
+            log.debug("Updated copy was not entered - not continuing.");
+            return;
+        }
+
+        property.setInitializer(StringUtils.quoteEscape(updatedCopy));
+        await cultureFile.save();
+    } catch (error) {
+        CoreUtils.catch("replaceTranslationByKey", error);
+    }
+};
+
+// #endregion Public Functions
+
+// -----------------------------------------------------------------------------------------
+// #region Exports
+// -----------------------------------------------------------------------------------------
+
+export { replaceTranslationByKey };
+
+// #endregion Exports

--- a/src/commands/replace-translation-by-key.ts
+++ b/src/commands/replace-translation-by-key.ts
@@ -79,7 +79,14 @@ const replaceTranslationByKey = async (
             propertyAssignments
         );
         if (property == null) {
-            log.warn("Could not find translation for key", key, resources);
+            log.warn(
+                "Could not find translation for key",
+                key,
+                cultureFilePath
+            );
+            WindowUtils.warning(
+                `Could not find translation for key '${key}' in ${cultureFile.getBaseName()}`
+            );
             return;
         }
 

--- a/src/constants/command-map.ts
+++ b/src/constants/command-map.ts
@@ -3,6 +3,7 @@ import { addKeyToInterface } from "../commands/add-key-to-interface";
 import { addTranslationToCultureFiles } from "../commands/add-translation-to-culture-files";
 import { removeKeyFromInterface } from "../commands/remove-key-from-interface";
 import { removeTranslationFromCultureFiles } from "../commands/remove-translation-from-culture-files";
+import { replaceTranslationByKey } from "../commands/replace-translation-by-key";
 import { replaceTranslationsFromFile } from "../commands/replace-translations-from-file";
 import { Commands } from "./commands";
 
@@ -16,6 +17,7 @@ const CommandMap: Record<string, (...args: any[]) => any> = {
     [Commands.addTranslationToCultureFiles]: addTranslationToCultureFiles,
     [Commands.removeKeyFromInterface]: removeKeyFromInterface,
     [Commands.removeTranslationFromCultureFiles]: removeTranslationFromCultureFiles,
+    [Commands.replaceTranslationByKey]: replaceTranslationByKey,
     [Commands.replaceTranslationsFromFile]: replaceTranslationsFromFile,
 };
 

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -9,6 +9,7 @@ const Commands = {
     removeKeyFromInterface: "kazoo.removeKeyFromInterface",
     removeTranslationFromCultureFiles:
         "kazoo.removeTranslationFromCultureFiles",
+    replaceTranslationByKey: "kazoo.replaceTranslationByKey",
     replaceTranslationsFromFile: "kazoo.replaceTranslationsFromFile",
 };
 

--- a/src/utilities/node-utils.ts
+++ b/src/utilities/node-utils.ts
@@ -83,7 +83,9 @@ const isObjectLiteralExpressionWithProperty = (
     node: Node,
     property: string
 ): node is ObjectLiteralExpression =>
-    Node.isObjectLiteralExpression(node) && node.getProperty(property) != null;
+    Node.isObjectLiteralExpression(node) &&
+    (node.getProperty(property) != null ||
+        node.getProperty(StringUtils.quoteEscape(property)) != null);
 
 const mapToPropertyAssignments = (
     object: Record<string, string>,

--- a/src/utilities/window-utils.ts
+++ b/src/utilities/window-utils.ts
@@ -53,8 +53,12 @@ const WindowUtils = {
             ignoreFocusOut: true,
         });
     },
-    selection(options: string[]): Thenable<string | undefined> {
+    selection(
+        options: string[],
+        placeHolder?: string
+    ): Thenable<string | undefined> {
         return vscode.window.showQuickPick(options, {
+            placeHolder,
             ignoreFocusOut: true,
         });
     },

--- a/src/utilities/window-utils.ts
+++ b/src/utilities/window-utils.ts
@@ -43,6 +43,16 @@ const WindowUtils = {
             ignoreFocusOut: true,
         });
     },
+    prefilledPrompt(
+        prompt: string,
+        value: string
+    ): Thenable<string | undefined> {
+        return vscode.window.showInputBox({
+            prompt,
+            value,
+            ignoreFocusOut: true,
+        });
+    },
     selection(options: string[]): Thenable<string | undefined> {
         return vscode.window.showQuickPick(options, {
             ignoreFocusOut: true,

--- a/src/utilities/window-utils.ts
+++ b/src/utilities/window-utils.ts
@@ -37,12 +37,6 @@ const WindowUtils = {
     info(value: string, ...options: MessageOption[]): void {
         showMessage(vscode.window.showInformationMessage)(value, ...options);
     },
-    prompt(prompt: string): Thenable<string | undefined> {
-        return vscode.window.showInputBox({
-            prompt,
-            ignoreFocusOut: true,
-        });
-    },
     prefilledPrompt(
         prompt: string,
         value: string
@@ -50,6 +44,12 @@ const WindowUtils = {
         return vscode.window.showInputBox({
             prompt,
             value,
+            ignoreFocusOut: true,
+        });
+    },
+    prompt(prompt: string): Thenable<string | undefined> {
+        return vscode.window.showInputBox({
+            prompt,
             ignoreFocusOut: true,
         });
     },


### PR DESCRIPTION
Resolve #2 Ability to replace copy for a specific key
Resolves #8 Add flexibility for object/initializer that is used for adding/updating copy in culture file 

Fits the primary use-case, though longer copy is still tedious to update (input box does not seem to scale to prefilled value, so it is one long string..). May benefit from a follow up feature that adds a setting to bring up the copy in an editor window with word-wrap auto-enabled if it exceeds some specific length, but this should be a good start.

For #8, I added support for reading from the first object literal in the culture file that contains the specified property. After doing some testing with our actual client files that are broken up in the way described in that issue, it was failing to find most of the keys that had already been professionally translated. If attempting to update a key that is not placed in the inline 'resources' object, it will prompt the user if they want to move the property to it for housekeeping purposes. (marking it as 'placeholder' translated)